### PR TITLE
Fix duplicate references within a schema

### DIFF
--- a/openapi_schema_to_json_schema/to_jsonschema.py
+++ b/openapi_schema_to_json_schema/to_jsonschema.py
@@ -1,4 +1,4 @@
-import copy
+import json
 
 
 class InvalidTypeError(ValueError):
@@ -41,7 +41,7 @@ def convert(schema, options=None):
     )
 
     if options['cloneSchema']:
-        schema = copy.deepcopy(schema)
+        schema = json.loads(json.dumps(schema))
 
     schema = convertSchema(schema, options)
     schema['$schema'] = 'http://json-schema.org/draft-04/schema#'

--- a/tests/to_jsonschema/test_clone_schema.py
+++ b/tests/to_jsonschema/test_clone_schema.py
@@ -45,3 +45,49 @@ def test_clone_schema_false():
     assert schema == expected
     assert result == expected
     assert schema is result
+
+
+def test_clone_schema_with_duplicate_references():
+    dupe = {
+        "oneOf": [
+            {
+                "type": "string",
+                "example": "cidr",
+                "nullable": True,
+            },
+            {
+                "type": "string",
+                "enum": ["alias", "policy"]
+            }
+        ]
+    }
+    schema = {
+        "type": "object",
+        "properties": {
+            "first": dupe,
+            "second": dupe,
+        }
+    }
+    result = convert(schema)
+    expected = {
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        "type": "object",
+        "properties": {
+            "first": {
+                "oneOf": [
+                    {"type": ["string", "null"]},
+                    {"type": "string", "enum": ["alias", "policy"]},
+                ],
+            },
+            "second": {
+                "oneOf": [
+                    {"type": ["string", "null"]},
+                    {"type": "string", "enum": ["alias", "policy"]},
+                ],
+            },
+        }
+    }
+
+    assert schema is not result
+    assert result == expected
+    assert result['properties']['first'] is not result['properties']['second']


### PR DESCRIPTION
It turns out that `copy.deepcopy()` memoizes during the copy pass. This
means that if you have duplicate references like the following, those
references are duplicates in the copy as well.

For example, the following structure has duplicate references to
`dupe_obj`.

```python
dupe_obj = {...}

data = {
  "type": "object",
  "properties": {
    "first": dupe_obj,
    "second": dupe_obj,
  }
}
```

`copy.deepcopy()` will only create a single copy of `dupe_obj` during
its copy pass, and place that single copy in two places in the result.

This would cause failures where the first pass over `first` field would
convert `dupe_obj` to json schema, and then `validateType` would fail
when it encounters the already-converted `dupe_obj` on the `second`
field.