### PR TITLE
Handle nullable=true with oneOf and anyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ about the problem.
 ## Features
 
 * converts OpenAPI 3.0 Schema Object to JSON Schema Draft 4
-* deletes `nullable` and adds `"null"` to `type` array if `nullable` is `true`
+* deletes `nullable` and adds `"null"` to `type` array if `nullable` is `true` and `type` is present
+* adds `{"type": "null"}` to `oneOf` or `anyOf` array if `nullable` is `true` and `type` is _not_ present
 * supports deep structures with nested `allOf`s etc.
 * removes [OpenAPI specific
   properties](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-20)

--- a/openapi_schema_to_json_schema/to_jsonschema.py
+++ b/openapi_schema_to_json_schema/to_jsonschema.py
@@ -162,6 +162,12 @@ def convertTypes(schema, options):
     toDateTime = options['dateToDateTime']
 
     if schema.get('type') is None:
+        # https://github.com/pglass/py-openapi-schema-to-json-schema/issues/10
+        if schema.get('nullable') is True:
+            for struct in ['oneOf', 'anyOf']:
+                if struct in schema:
+                    schema[struct].append({'type': 'null'})
+
         return schema
 
     if (schema.get('type') == 'string' and schema.get('format') == 'date'

--- a/tests/to_jsonschema/test_nullable.py
+++ b/tests/to_jsonschema/test_nullable.py
@@ -23,3 +23,21 @@ def test_handles_nullable():
         "type": 'string'
     }
     assert result == expected
+
+
+def test_nullable_oneOf_anyOf():
+    # https://github.com/pglass/py-openapi-schema-to-json-schema/issues/10
+    for key in ['oneOf', 'anyOf']:
+        schema = {
+            key: [{"type": "string"}],
+            "nullable": True,
+        }
+        result = convert(schema)
+        expected = {
+            "$schema": 'http://json-schema.org/draft-04/schema#',
+            key: [
+                {"type": "string"},
+                {"type": "null"},
+            ]
+        }
+        assert result == expected


### PR DESCRIPTION
- If `nullable=True` is alongside a `oneOf`/`anyOf` field, then
add `{"type": "null"}` to the `oneOf`/`anyOf` arrray.
- This activates only if there is no `type` field alongside the `oneOf`
or `anyOf` field

This helps ensure the resulting JSON Schema actually accepts null
when using nullable with oneOf/anyOf